### PR TITLE
Feature/scaffold aws infrastructure as code for api deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,23 @@
 # dotenv files
 .env
 
+# OpenTofu / Terraform state and config files
+*.tfstate
+*.tfstate.*
+.opentofu/
+.terraform/
+terraform.tfstate
+terraform.tfstate.*
+opentofu.tfstate
+opentofu.tfstate.*
+
+# .tfvars files containing secrets (recommend you name them secrets.*.tfvars or *.auto.tfvars, etc)
+*.tfvars
+*.tfvars.json
+
+# Ignore files with sensitive deployment info
+secrets.json
+
 # User-specific files
 *.rsuser
 *.suo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+COPY ./API/API.csproj ./API/
+COPY ./Core/Core.csproj ./Core/
+COPY ./Infrastructure/Infrastructure.csproj ./Infrastructure/
+COPY ./devops-lab-app.sln ./
+
+RUN dotnet restore ./API/API.csproj
+
+COPY . .
+
+WORKDIR /src/API
+RUN dotnet publish -c Release -o /app/out
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
+WORKDIR /app
+COPY --from=build /app/out .
+ENV ASPNETCORE_URLS=http://+:80
+EXPOSE 80
+ENTRYPOINT ["dotnet", "API.dll"]

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version = "5.99.1"
+  hashes = [
+    "h1:/wcdT1vrAktWvNolQbBBy3xThqtZtAMoLJAU2d/i8xM=",
+    "zh:13a07422f776dd97214dfa89d6a88340b99613cbb869013c756c1a68fd8cdd9d",
+    "zh:1841d422278afa25d42a8d3ea9197ad08cf092769bd2aa89056d25d4c2629df8",
+    "zh:269016c7ba09d76e42fbcf15de28f2de0595ff9a7304a0500011a4493d7a1551",
+    "zh:2b842c3d0f30e048c05a37752b9c07d316656f3caf79841d08a4f1b057555eb2",
+    "zh:6559eedc095f70a51460dc702613a9033734ba536c1de1ed86a735a3c8131e40",
+    "zh:6d43b2676630344db3a7d6ba8330d20993492168f124e19e040a0aa914ec832e",
+    "zh:7f5d5cb0c1a492080b668f456de50f5b91fc67018c05f12483added3faf703f6",
+    "zh:c3bb8094bf26565150229f1ca6014d41d1283b8a2b06a15b45cd5a6b4ce82e28",
+    "zh:e45bc994d0c6e1c0a0b70e8378f2f933e924f05c91061ed2a97ceaf282e08a25",
+    "zh:ee725d6fbc1dbaa5017e9eab6fa0aa7e107a4ed73a4a8e2acab6b5d3d54cd0e4",
+  ]
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,179 @@
+resource "aws_ecr_repository" "api" {
+  name = "infraforge-api"
+}
+
+# VPC (simplest option: use default VPC for now)
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+# ECS Cluster
+resource "aws_ecs_cluster" "main" {
+  name = "infraforge-cluster"
+}
+
+resource "aws_iam_role" "ecs_task_execution" {
+  name = "ecsTaskExecutionRole"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = {
+        Service = "ecs-tasks.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_policy" {
+  role       = aws_iam_role.ecs_task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_cloudwatch_log_group" "ecs_api" {
+  name              = "/ecs/infraforge-api"
+  retention_in_days = 7
+}
+
+resource "aws_ecs_task_definition" "api" {
+  family                   = "infraforge-api"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "256"    # 0.25 vCPU
+  memory                   = "512"    # 0.5 GB RAM
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "api"
+      image     = "${aws_ecr_repository.api.repository_url}:latest"
+      essential = true
+      portMappings = [
+        {
+          containerPort = 80
+          hostPort      = 80
+          protocol      = "tcp"
+        }
+      ]
+      environment = [
+    {
+        name  = "ConnectionStrings__DefaultConnection"
+        value = "Host=${aws_db_instance.postgres.endpoint};Port=5432;Database=${var.db_name};Username=${var.db_username};Password=${var.db_password}"
+    }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = "/ecs/infraforge-api"
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+    }
+  ])
+}
+
+# Security group for the ECS tasks (allow inbound HTTP from ALB)
+resource "aws_security_group" "api" {
+  name        = "infraforge-api-sg"
+  description = "Allow HTTP inbound from ALB"
+  vpc_id      = data.aws_vpc.default.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]  # Open to the internet (for now)
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# Application Load Balancer (public)
+resource "aws_lb" "api" {
+  name               = "infraforge-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.api.id]
+  subnets            = data.aws_subnets.default.ids
+}
+
+# Target Group (for ALB to route traffic to ECS tasks)
+resource "aws_lb_target_group" "api" {
+  name        = "infraforge-tg"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = data.aws_vpc.default.id
+  target_type = "ip"
+  health_check {
+    path                = "/"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    matcher             = "200"
+  }
+}
+
+resource "aws_lb_listener" "api" {
+  load_balancer_arn = aws_lb.api.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.api.arn
+  }
+}
+
+resource "aws_ecs_service" "api" {
+  name            = "infraforge-api-svc"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.api.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = data.aws_subnets.default.ids
+    security_groups  = [aws_security_group.api.id]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.api.arn
+    container_name   = "api"
+    container_port   = 80
+  }
+
+  depends_on = [aws_lb_listener.api]
+}
+
+resource "aws_db_instance" "postgres" {
+  identifier              = "infraforge-db"
+  engine                  = "postgres"
+  instance_class          = "db.t3.micro"
+  allocated_storage       = 20
+  db_name                    = var.db_name
+  username                = var.db_username
+  password                = var.db_password
+  publicly_accessible     = true # For demo/dev only! (Lock down in production)
+  skip_final_snapshot     = true
+  vpc_security_group_ids  = [aws_security_group.api.id]
+}
+
+
+

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,7 @@
+output "alb_dns_name" {
+  value = aws_lb.api.dns_name
+}
+
+output "db_endpoint" {
+  value = aws_db_instance.postgres.endpoint
+}

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+    region = var.aws_region
+}
+
+variable "aws_region" {
+    description = "AWS Region for deployment"
+    default = "us-west-2"
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,21 @@
+variable "db_username" {
+  description = "Username for RDS"
+  type        = string
+}
+
+variable "db_password" {
+  description = "Password for RDS"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_name" {
+  description = "Database name"
+  default     = "devopsdb"
+}
+
+variable "app_image_tag" {
+  description = "ECR Docker image tag to deploy"
+  type        = string
+}
+


### PR DESCRIPTION
- Added /infra directory with OpenTofu (Terraform) files:
  - AWS provider configuration
  - Variables and outputs setup
  - ECR repository resource for Docker images
  - ECS cluster, IAM roles, and Fargate task definition
  - Security group and VPC data source for networking
  - Application Load Balancer and target group
  - ECS service resource wired to ALB
  - Initial RDS PostgreSQL DB resource and output
- Created a Dockerfile for containerizing the API (multi-project .NET solution)
- Updated README with initial deployment instructions

This lays the foundation for a production-grade, cloud-native deployment pipeline using AWS ECS Fargate, ECR, RDS, and ALB, managed entirely via infrastructure-as-code.